### PR TITLE
Update projects.ts

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -795,14 +795,6 @@ export const projects: ProjectLink[] = [
     categories: ['validators', 'information']
   },
   { 
-    name: 'Validators Telegram group',
-    url: 'https://t.me/transparentvalidatorchat',
-    description: 'Community Chat',
-    indicator: 'support',
-    logo: '/public/logos/validators/telegram.svg',
-    categories: ['validators', 'information']
-  },
-  { 
     name: 'Vultisig',
     url: 'https://vultisig.com',
     description: 'Multisig Wallet',


### PR DESCRIPTION
Remove validators telegram group from resources , I believe this listing should be removed because it is no longer suitable as a public community resource. Since it appears on the website, users may reasonably interpret it as a trusted ecosystem link, so removing it is the safest option for now.